### PR TITLE
Python 2 compatibility for Nanomine

### DIFF
--- a/setlr/__init__.py
+++ b/setlr/__init__.py
@@ -136,7 +136,7 @@ def read_csv(location, result):
         sep = result.value(csvw.delimiter, default=Literal(",")).value,
         #header = result.value(csvw.headerRow, default=Literal(0)).value),
         skiprows = result.value(csvw.skipRows, default=Literal(0)).value,
-        # dtype = object
+        # dtype = object    # Does not seem to play well with future and python2/3 conversion
     )
     if result.value(csvw.header):
         args['header'] = [0]
@@ -173,11 +173,13 @@ class FileLikeFromIter(object):
         self.data = b''
 
     def __iter__(self):
-        return self.iter    # TODO Might need to be return self
+        return self.iter
 
+    # Enter and Exit are needed to allow this to work with with
     def __enter__(self):
         return self
 
+    # Could be improved for better error/exception handling
     def __exit__(self, err_type, value, tracebock):
         pass
 

--- a/setlr/__init__.py
+++ b/setlr/__init__.py
@@ -136,7 +136,7 @@ def read_csv(location, result):
         sep = result.value(csvw.delimiter, default=Literal(",")).value,
         #header = result.value(csvw.headerRow, default=Literal(0)).value),
         skiprows = result.value(csvw.skipRows, default=Literal(0)).value,
-        dtype = object
+        # dtype = object
     )
     if result.value(csvw.header):
         args['header'] = [0]
@@ -173,7 +173,13 @@ class FileLikeFromIter(object):
         self.data = b''
 
     def __iter__(self):
-        return self.iter
+        return self.iter    # TODO Might need to be return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, err_type, value, tracebock):
+        pass
 
     def read(self, n=None):
         if n is None:
@@ -415,7 +421,7 @@ def get_function(expr, local_keys):
     if key not in functions:
         script = '''lambda %s: %s'''% (', '.join(sorted(local_keys)), expr)
         fn = eval(script)
-        fn.__name__ = str(expr)
+        fn.__name__ = expr.encode("ascii", "ignore")
         functions[key] = fn
     return functions[key]
 

--- a/setlr/iterparse_filter.py
+++ b/setlr/iterparse_filter.py
@@ -13,6 +13,8 @@ from builtins import object
 __version__ = "0.9-experimental"
 
 import re
+import io
+import StringIO
 
 dtd_validation = False
 try:
@@ -402,7 +404,10 @@ class FilterAutomata(object):
         last_start = 0
         total_mem = 0
         before = None
-        for (event, ele) in etree.iterparse(file, needed_actions, **kwargs):
+        xml_bytes = io.BytesIO(file.read()) # iterparse doesn't like file, so we need to preprocess it
+        xml_str = xml_bytes.read()
+        xml_str = xml_str[xml_str.find("xml_str") + 52:-4]  # Need to figure out a better way to do this
+        for (event, ele) in etree.iterparse(StringIO.StringIO(xml_str), needed_actions, **kwargs):
             if event == "start":
                 tag = ele.tag
                 # Descend into node; track where I am

--- a/setlr/iterparse_filter.py
+++ b/setlr/iterparse_filter.py
@@ -407,6 +407,7 @@ class FilterAutomata(object):
         xml_bytes = io.BytesIO(file.read()) # iterparse doesn't like file, so we need to preprocess it
         xml_str = xml_bytes.read()
         xml_str = xml_str[xml_str.find(">") + 1 : -4]  # iterparse doesn't seem to like having the xml header
+        xml_str = xml_str.replace('\\"', '"')
         for (event, ele) in etree.iterparse(StringIO.StringIO(xml_str), needed_actions, **kwargs):
             if event == "start":
                 tag = ele.tag

--- a/setlr/iterparse_filter.py
+++ b/setlr/iterparse_filter.py
@@ -13,8 +13,6 @@ from builtins import object
 __version__ = "0.9-experimental"
 
 import re
-import io
-import StringIO
 
 dtd_validation = False
 try:
@@ -404,11 +402,6 @@ class FilterAutomata(object):
         last_start = 0
         total_mem = 0
         before = None
-        # xml_bytes = io.BytesIO(file.read()) # iterparse doesn't like file, so we need to preprocess it
-        # xml_str = xml_bytes.read()
-        # xml_str = xml_str[xml_str.find(">") + 1 : -4]  # iterparse doesn't seem to like having the xml header
-        # xml_str = xml_str.replace('\\"', '"')
-        # crash = self / 0
         for (event, ele) in etree.iterparse(file, needed_actions, **kwargs):
             if event == "start":
                 tag = ele.tag

--- a/setlr/iterparse_filter.py
+++ b/setlr/iterparse_filter.py
@@ -404,11 +404,12 @@ class FilterAutomata(object):
         last_start = 0
         total_mem = 0
         before = None
-        xml_bytes = io.BytesIO(file.read()) # iterparse doesn't like file, so we need to preprocess it
-        xml_str = xml_bytes.read()
-        xml_str = xml_str[xml_str.find(">") + 1 : -4]  # iterparse doesn't seem to like having the xml header
-        xml_str = xml_str.replace('\\"', '"')
-        for (event, ele) in etree.iterparse(StringIO.StringIO(xml_str), needed_actions, **kwargs):
+        # xml_bytes = io.BytesIO(file.read()) # iterparse doesn't like file, so we need to preprocess it
+        # xml_str = xml_bytes.read()
+        # xml_str = xml_str[xml_str.find(">") + 1 : -4]  # iterparse doesn't seem to like having the xml header
+        # xml_str = xml_str.replace('\\"', '"')
+        # crash = self / 0
+        for (event, ele) in etree.iterparse(file, needed_actions, **kwargs):
             if event == "start":
                 tag = ele.tag
                 # Descend into node; track where I am

--- a/setlr/iterparse_filter.py
+++ b/setlr/iterparse_filter.py
@@ -406,7 +406,7 @@ class FilterAutomata(object):
         before = None
         xml_bytes = io.BytesIO(file.read()) # iterparse doesn't like file, so we need to preprocess it
         xml_str = xml_bytes.read()
-        xml_str = xml_str[xml_str.find("xml_str") + 52:-4]  # Need to figure out a better way to do this
+        xml_str = xml_str[xml_str.find(">") + 1 : -4]  # iterparse doesn't seem to like having the xml header
         for (event, ele) in etree.iterparse(StringIO.StringIO(xml_str), needed_actions, **kwargs):
             if event == "start":
                 tag = ele.tag


### PR DESCRIPTION
Some changes which I found required to allow for the nanomine tests to run, it seems like there are some python 2/3 issues going on.  Best I can tell the changes I made should work with both, the main thing was the addition of the `__enter__` and `__exit__` functions to allow the fileLikeFromIter class to be opened with `with`.