### PR TITLE
Change read_json to return a generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.vscode/settings.json

--- a/setlr/__init__.py
+++ b/setlr/__init__.py
@@ -269,7 +269,8 @@ def read_json(location, result):
     else:
         selector = ""
     with get_content(location, result) as fo:
-        return enumerate(ijson.items(fo, selector))
+        for item in enumerate(ijson.items(fo, selector)):
+            yield item
             
 
 extractors = {

--- a/setlr/__init__.py
+++ b/setlr/__init__.py
@@ -269,8 +269,7 @@ def read_json(location, result):
     else:
         selector = ""
     with get_content(location, result) as fo:
-        for item in enumerate(ijson.items(fo, selector)):
-            yield item
+        yield from enumerate(ijson.items(fo, selector))
             
 
 extractors = {

--- a/tests/setlr_test/test_read_json.json
+++ b/tests/setlr_test/test_read_json.json
@@ -1,0 +1,30 @@
+[
+    {
+      "ID": "Alice",
+      "Name": "Alice Smith",
+      "MarriedTo": "Bob",
+      "Knows": "Bob; Charles",
+      "DOB": "1/12/1983"
+    },
+    {
+      "ID": "Bob",
+      "Name": "Bob Smith",
+      "MarriedTo": "Alice",
+      "Knows": "Alice; Charles",
+      "DOB": "3/23/1985"
+    },
+    {
+      "ID": "Charles",
+      "Name": "Charles Brown",
+      "MarriedTo": "",
+      "Knows": "Alice; Bob",
+      "DOB": "12/15/1955"
+    },
+    {
+      "ID": "Dave",
+      "Name": "Dave Jones",
+      "MarriedTo": "",
+      "Knows": "",
+      "DOB": "4/25/1967"
+    }
+]

--- a/tests/setlr_test/test_read_json.py
+++ b/tests/setlr_test/test_read_json.py
@@ -1,0 +1,50 @@
+import unittest
+import rdflib
+import json
+
+from setlr import read_json
+
+# Checks the the file stays open through reading
+class TestReadJson(unittest.TestCase):
+    def test_read_json(self):
+        expected_string = '''
+        [
+            {
+              "ID": "Alice",
+              "Name": "Alice Smith",
+              "MarriedTo": "Bob",
+              "Knows": "Bob; Charles",
+              "DOB": "1/12/1983"
+            },
+            {
+              "ID": "Bob",
+              "Name": "Bob Smith",
+              "MarriedTo": "Alice",
+              "Knows": "Alice; Charles",
+              "DOB": "3/23/1985"
+            },
+            {
+              "ID": "Charles",
+              "Name": "Charles Brown",
+              "MarriedTo": "",
+              "Knows": "Alice; Bob",
+              "DOB": "12/15/1955"
+            },
+            {
+              "ID": "Dave",
+              "Name": "Dave Jones",
+              "MarriedTo": "",
+              "Knows": "",
+              "DOB": "4/25/1967"
+            }
+        ]
+        '''
+        expected_json = json.loads(expected_string)
+        
+        result = read_json(("file:///apps/setlr/tests/setlr_test/test_read_json.json"), rdflib.resource.Resource(rdflib.graph.Graph(), "test_read_json"))
+        result = [r for r in result]      
+
+        self.assertCountEqual(expected_json, result[0][1], "JSON objects not equal")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/setlr_test/test_read_json.py
+++ b/tests/setlr_test/test_read_json.py
@@ -10,13 +10,13 @@ class TestReadJson(unittest.TestCase):
     def test_read_json(self):
         expected_string = ''
         root_dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-        json_file = root_dir_path + "/tests/setlr_test/test_read_json.json"
+        json_file = os.path.join(root_dir_path, "tests", "setlr_test", "test_read_json.json")
         with open(json_file) as f:
             expected_string = f.read()
         expected_json = json.loads(expected_string)
         
         result = read_json(("file://{}".format(json_file)), rdflib.resource.Resource(rdflib.graph.Graph(), "test_read_json"))
-        result = [r for r in result]      
+        result = list(result)
 
         self.assertCountEqual(expected_json, result[0][1], "JSON objects not equal")
 

--- a/tests/setlr_test/test_read_json.py
+++ b/tests/setlr_test/test_read_json.py
@@ -1,6 +1,7 @@
 import unittest
 import rdflib
 import json
+import os
 
 from setlr import read_json
 
@@ -8,7 +9,8 @@ from setlr import read_json
 class TestReadJson(unittest.TestCase):
     def test_read_json(self):
         expected_string = ''
-        json_file = "tests/setlr_test/test_read_json.json"
+        root_dir_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+        json_file = root_dir_path + "/tests/setlr_test/test_read_json.json"
         with open(json_file) as f:
             expected_string = f.read()
         expected_json = json.loads(expected_string)

--- a/tests/setlr_test/test_read_json.py
+++ b/tests/setlr_test/test_read_json.py
@@ -7,41 +7,13 @@ from setlr import read_json
 # Checks the the file stays open through reading
 class TestReadJson(unittest.TestCase):
     def test_read_json(self):
-        expected_string = '''
-        [
-            {
-              "ID": "Alice",
-              "Name": "Alice Smith",
-              "MarriedTo": "Bob",
-              "Knows": "Bob; Charles",
-              "DOB": "1/12/1983"
-            },
-            {
-              "ID": "Bob",
-              "Name": "Bob Smith",
-              "MarriedTo": "Alice",
-              "Knows": "Alice; Charles",
-              "DOB": "3/23/1985"
-            },
-            {
-              "ID": "Charles",
-              "Name": "Charles Brown",
-              "MarriedTo": "",
-              "Knows": "Alice; Bob",
-              "DOB": "12/15/1955"
-            },
-            {
-              "ID": "Dave",
-              "Name": "Dave Jones",
-              "MarriedTo": "",
-              "Knows": "",
-              "DOB": "4/25/1967"
-            }
-        ]
-        '''
+        expected_string = ''
+        json_file = "tests/setlr_test/test_read_json.json"
+        with open(json_file) as f:
+            expected_string = f.read()
         expected_json = json.loads(expected_string)
         
-        result = read_json(("file:///apps/setlr/tests/setlr_test/test_read_json.json"), rdflib.resource.Resource(rdflib.graph.Graph(), "test_read_json"))
+        result = read_json(("file://{}".format(json_file)), rdflib.resource.Resource(rdflib.graph.Graph(), "test_read_json"))
         result = [r for r in result]      
 
         self.assertCountEqual(expected_json, result[0][1], "JSON objects not equal")


### PR DESCRIPTION
Currently the file is closed before being read, by changing it to use a generator it keeps the file open for the expected duration.